### PR TITLE
Write the full StackTraceElement in TimeoutException message

### DIFF
--- a/src/main/java/io/vertx/junit5/VertxExtension.java
+++ b/src/main/java/io/vertx/junit5/VertxExtension.java
@@ -197,11 +197,10 @@ public final class VertxExtension implements ParameterResolver, BeforeTestExecut
           String message = "The test execution timed out. Make sure your asynchronous code "
             + "includes calls to either VertxTestContext#completeNow(), VertxTestContext#failNow() "
             + "or Checkpoint#flag()";
-          String unsatisfiedCheckpointsDiagnosis = context.unsatisfiedCheckpointCallSites()
+          message = message +  context.unsatisfiedCheckpointCallSites()
             .stream()
-            .map(element -> "-> checkpoint in file " + element.getFileName() + " line " + element.getLineNumber())
-            .collect(Collectors.joining("\n"));
-          message = message + "\n\nUnsatisfied checkpoints diagnostics:\n" + unsatisfiedCheckpointsDiagnosis;
+            .map(element -> String.format("-> checkpoint at %s", element))
+            .collect(Collectors.joining("\n", "\n\nUnsatisfied checkpoints diagnostics:\n", ""));
           throw new TimeoutException(message);
         }
       }

--- a/src/test/java/io/vertx/junit5/VertxExtensionTest.java
+++ b/src/test/java/io/vertx/junit5/VertxExtensionTest.java
@@ -264,7 +264,7 @@ class VertxExtensionTest {
       Throwable exception = summary.getFailures().get(0).getException();
       assertThat(exception)
         .isInstanceOf(TimeoutException.class)
-        .hasMessageContaining("checkpoint in file VertxExtensionTest.java");
+        .hasMessageContaining("checkpoint at io.vertx.junit5.VertxExtensionTest$EmbeddedWithARunner$TimingOut");
     }
   }
 


### PR DESCRIPTION
Motivation:

Write the full StackTraceElement in TimeoutException message instead of the file name and line number only
 - The package of the file/class is displayed
 - The method in which the checkpoint is located is displayed
 - In test runners of IDEs, the TimeoutException will be displayed in a console and the console is formated in order to make the StackTraceElements clickable
