### PR TITLE
Ensure test context throws exception if further assertions made after context completed/failed

### DIFF
--- a/src/main/java/io/vertx/junit5/CheckpointFlagOverUseException.java
+++ b/src/main/java/io/vertx/junit5/CheckpointFlagOverUseException.java
@@ -1,0 +1,7 @@
+package io.vertx.junit5;
+
+public class CheckpointFlagOverUseException extends IllegalStateException {
+  public CheckpointFlagOverUseException(String s) {
+    super(s);
+  }
+}

--- a/src/main/java/io/vertx/junit5/CountingCheckpoint.java
+++ b/src/main/java/io/vertx/junit5/CountingCheckpoint.java
@@ -82,7 +82,7 @@ final class CountingCheckpoint implements Checkpoint {
     if (callSatisfactionTrigger) {
       satisfactionTrigger.accept(this);
     } else if (callOveruseTrigger && overuseTrigger != null) {
-      overuseTrigger.accept(new IllegalStateException("Strict checkpoint flagged too many times"));
+      overuseTrigger.accept(new CheckpointFlagOverUseException("Strict checkpoint flagged too many times"));
     }
   }
 

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -476,8 +476,6 @@ class VertxTestContextTest {
     illegalStateException.isThrownBy(context::succeedingThenComplete);
     illegalStateException.isThrownBy(context::failingThenComplete);
     illegalStateException.isThrownBy(context::completeNow);
-    illegalStateException.isThrownBy(() -> context.failNow("X"));
-    illegalStateException.isThrownBy(() -> context.failNow(new Throwable()));
     illegalStateException.isThrownBy(() -> context.succeeding(null));
     illegalStateException.isThrownBy(() -> context.failing(null));
   }
@@ -493,7 +491,7 @@ class VertxTestContextTest {
 
     checkpoint.flag();
     assertThat(context.failed()).isTrue();
-    assertThat(context.causeOfFailure()).isInstanceOf(IllegalStateException.class);
+    assertThat(context.causeOfFailure()).isInstanceOf(CheckpointFlagOverUseException.class);
     assertThat(context.causeOfFailure()).hasMessage("Strict checkpoint flagged too many times");
   }
 }

--- a/src/test/java/io/vertx/junit5/VertxTestContextTest.java
+++ b/src/test/java/io/vertx/junit5/VertxTestContextTest.java
@@ -476,6 +476,7 @@ class VertxTestContextTest {
     illegalStateException.isThrownBy(context::succeedingThenComplete);
     illegalStateException.isThrownBy(context::failingThenComplete);
     illegalStateException.isThrownBy(context::completeNow);
+    illegalStateException.isThrownBy(() -> context.verify(() -> {}));
     illegalStateException.isThrownBy(() -> context.succeeding(null));
     illegalStateException.isThrownBy(() -> context.failing(null));
   }


### PR DESCRIPTION
Motivation:

Currently it's possible to write tests where the test context is accidentally completed, causing further assertions later in the code to be ignored. This could cause tests to pass when they should fail. Please see #106 for more details.

Conformance:

I've just signed the ECA, but the check isn't able to match me up yet. 
