### PR TITLE
Add a convenient way to run assertions on vertx test context

### DIFF
--- a/src/main/java/io/vertx/junit5/VertxAssertions.java
+++ b/src/main/java/io/vertx/junit5/VertxAssertions.java
@@ -1,0 +1,152 @@
+package io.vertx.junit5;
+
+import org.junit.jupiter.api.Assertions;
+
+/** VertxAssertions */
+public class VertxAssertions {
+
+  public static <T> void assertEquals(VertxTestContext testContext, T expected, T actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, byte expected, byte actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, short expected, short actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, int expected, int actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, long expected, long actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, float expected, float actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, double expected, double actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, boolean expected, boolean actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertEquals(VertxTestContext testContext, char expected, char actual) {
+    try {
+      Assertions.assertEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static <T> void assertNotEquals(VertxTestContext testContext, T expected, T actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, byte expected, byte actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, short expected, short actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, int expected, int actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, long expected, long actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, float expected, float actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, double expected, double actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(
+      VertxTestContext testContext, boolean expected, boolean actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+
+  public static void assertNotEquals(VertxTestContext testContext, char expected, char actual) {
+    try {
+      Assertions.assertNotEquals(expected, actual);
+    } catch (Throwable t) {
+      testContext.failNow(t);
+    }
+  }
+}

--- a/src/main/java/io/vertx/junit5/VertxAssertions.java
+++ b/src/main/java/io/vertx/junit5/VertxAssertions.java
@@ -3,7 +3,7 @@ package io.vertx.junit5;
 import org.junit.jupiter.api.Assertions;
 
 /** VertxAssertions */
-public class VertxAssertions {
+public interface VertxAssertions {
 
   public static <T> void assertEquals(VertxTestContext testContext, T expected, T actual) {
     try {

--- a/src/main/java/io/vertx/junit5/VertxTestContext.java
+++ b/src/main/java/io/vertx/junit5/VertxTestContext.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  *
  * @author <a href="https://julien.ponge.org/">Julien Ponge</a>
  */
-public final class VertxTestContext {
+public final class VertxTestContext implements VertxAssertions {
 
   /**
    * Interface for an executable block of assertion code.

--- a/src/test/java/io/vertx/junit5/VertxAssertionsTest.java
+++ b/src/test/java/io/vertx/junit5/VertxAssertionsTest.java
@@ -1,0 +1,65 @@
+package io.vertx.junit5;
+
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** VertxAssertionsTest */
+@ExtendWith(VertxExtension.class)
+public class VertxAssertionsTest {
+
+  @Test
+  public void testAssertEqualsReference(Vertx vertx, VertxTestContext testContext) {
+    VertxAssertions.assertEquals(testContext, null, null);
+    VertxAssertions.assertEquals(testContext, "hello", "hello");
+    VertxAssertions.assertEquals(testContext, Integer.valueOf(0), Integer.valueOf(0));
+
+    testContext.completeNow();
+  }
+
+  @Test
+  public void testAssertEqualsPrimitive(Vertx vertx, VertxTestContext testContext) {
+
+    VertxAssertions.assertEquals(testContext, (byte) 1, (byte) 1);
+    VertxAssertions.assertEquals(testContext, 2, 2);
+    VertxAssertions.assertEquals(testContext, 3L, 3L);
+    VertxAssertions.assertEquals(testContext, (short) 4, (short) 4);
+    VertxAssertions.assertEquals(testContext, (float) 5.0, (float) 5.0);
+    VertxAssertions.assertEquals(testContext, (double) 6.0, (double) 6.0);
+
+    VertxAssertions.assertEquals(testContext, true, true);
+    VertxAssertions.assertEquals(testContext, false, false);
+
+    VertxAssertions.assertEquals(testContext, 'a', 'a');
+    VertxAssertions.assertEquals(testContext, '\u0000', '\u0000');
+
+    testContext.completeNow();
+  }
+
+  @Test
+  public void testAssertNotEqualsReference(Vertx vertx, VertxTestContext testContext) {
+    VertxAssertions.assertNotEquals(testContext, "hello", "world");
+    VertxAssertions.assertNotEquals(testContext, Integer.valueOf(0), Integer.valueOf(1));
+
+    testContext.completeNow();
+  }
+
+  @Test
+  public void testAssertNotEqualsPrimitive(Vertx vertx, VertxTestContext testContext) {
+
+    VertxAssertions.assertNotEquals(testContext, (byte) 1, (byte) 2);
+    VertxAssertions.assertNotEquals(testContext, 2, 3);
+    VertxAssertions.assertNotEquals(testContext, 3L, 4L);
+    VertxAssertions.assertNotEquals(testContext, (short) 4, (short) 5);
+    VertxAssertions.assertNotEquals(testContext, (float) 5.0, (float) 6.0);
+    VertxAssertions.assertNotEquals(testContext, (double) 6.0, (double) 7.0);
+
+    VertxAssertions.assertNotEquals(testContext, true, false);
+    VertxAssertions.assertNotEquals(testContext, false, true);
+
+    VertxAssertions.assertNotEquals(testContext, 'a', 'b');
+    VertxAssertions.assertNotEquals(testContext, '\u0000', '\uffff');
+
+    testContext.completeNow();
+  }
+}


### PR DESCRIPTION
Motivation:

Assertions will throw exception, so when test fail, it need to wait test context timeout to fail, or it need to wrap try/catch around the assertions.
To avoid this, I will to implement a vertx version assertions to call vertx test context fail method on failure.

It's mostly a physical labor job, so I've only provided a very start implements of it, to see if it useful and necessary.

Or, if there a better way to run the tests or too implement this feature?

Further on, if we really need this, we can also implement the methods as instance methods of VertxTestContext, so we could invoke them like testContext.assertEquals(x, y).