### PR TITLE
Rename vertx-junit5-extensions to reactiverse-junit5-extensions

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -221,7 +221,7 @@ https://github.com/reactiverse/reactiverse-junit5-extensions.
 == Parameter ordering
 
 It may be the case that a parameter type has to be placed before another parameter.
-For instance the Web Client support in the `vertx-junit5-extensions` project requires that the `Vertx` argument is before the `WebClient` argument.
+For instance the Web Client support in the `reactiverse-junit5-extensions` project requires that the `Vertx` argument is before the `WebClient` argument.
 This is because the `Vertx` instance needs to exist to create the `WebClient`.
 
 It is expected that parameter providers throw meaningful exceptions to let users know of possible ordering constraints.


### PR DESCRIPTION
Motivation:

Update the reference after vertx-junit5-extensions has been renamed to reactiverse-junit5-extensions.

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
